### PR TITLE
Remove dierction member from table metadata.

### DIFF
--- a/include/manager/metadata/tables.h
+++ b/include/manager/metadata/tables.h
@@ -27,36 +27,6 @@
 namespace manager::metadata {
 
 struct Column {
-  /**
-   * @brief represents sort direction of elements.
-   */
-  enum class Direction {
-    /**
-     * @brief unsupported order. e.g.) SORTBY_USING
-     */
-    UNSUPPORTED = 99,
-
-    /**
-     * @brief direction is none, so this column is not index.
-     */
-    NONE = -1,
-
-    /**
-     * @brief default order.
-     */
-    DEFAULT = 0,
-
-    /**
-     * @brief ascendant order.
-     */
-    ASCENDANT,
-
-    /**
-     * @brief descendant order.
-     */
-    DESCENDANT,
-  };
-
 	Column() {}
   int64_t       id;
   int64_t       table_id;
@@ -67,7 +37,6 @@ struct Column {
   bool          varying;
   bool          nullable;
   std::string   default_expr;
-  int64_t       direction;
 };
 
 struct Table {

--- a/src/tables.cpp
+++ b/src/tables.cpp
@@ -508,7 +508,6 @@ ptree transform_to_ptree(const Table& table)
     ptree_column.put<bool>(Tables::Column::VARYING, column.varying);  
     ptree_column.put<bool>(Tables::Column::NULLABLE, column.nullable);  
     ptree_column.put(Tables::Column::DEFAULT, column.default_expr);  
-    ptree_column.put<int64_t>(Tables::Column::DIRECTION, static_cast<int64_t>(column.direction));  
 
 #if 0
     ptree data_length;
@@ -619,8 +618,6 @@ Table transform_from_ptree(const ptree& ptree_table)
     name              ? column.name = name.get()            : column.name = "";
     varying           ? column.varying = varying.get()      : column.varying = 0;
     nullable          ? column.nullable = nullable.get()    : column.nullable = 0;
-    direction         ? column.direction = static_cast<int64_t>(direction.get()) 
-                      : column.direction = static_cast<int64_t>(Column::Direction::NONE);
     ordinal_position  ? column.ordinal_position = ordinal_position.get() : column.ordinal_position = 0;
     data_type_id      ? column.data_type_id = data_type_id.get()  : column.data_type_id = 0;
     default_expr      ? column.default_expr = default_expr.get()  : column.default_expr = "";


### PR DESCRIPTION
- Remove direction metadata from table mtadata.
- Direction metadata should be moved from table metadata to index metadata.