### PR TITLE
Update ci-build.yml

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,6 +26,7 @@ jobs:
       - id: Make_CI_Directory
         name: Make_CI_Directory
         run: |
+          cd ${GITHUB_WORKSPACE}
           rm -rf ci_test
           mkdir ci_test
 


### PR DESCRIPTION
CIが正しく動作するように修正しました
※誤ったコードは失敗するようになりました

■変更内容
・metadata-managerをインストールするディレクトリ(ci_test)を指定するように変更
・cmake時にbuildするパスを指定しないように変更
・CI処理後、ディレクトリ(ci_test)を削除するように変更
