### PR TITLE
add missing include (for FTBFS with gcc-10)

### DIFF
--- a/include/manager/metadata/log/logging.h
+++ b/include/manager/metadata/log/logging.h
@@ -17,6 +17,7 @@
 #define MANAGER_METADATA_LOG_LOGGING_H_
 
 #include <memory>
+#include <string_view>
 
 namespace manager::metadata::log::logging {
 


### PR DESCRIPTION
libstdc++ の内部構成変更に伴い、 g++ の version 10, version 11 でビルドするとコンパイルエラーとなる問題への対応です。
参考情報: https://gcc.gnu.org/gcc-10/porting_to.html#header-dep-changes