### PR TITLE
fix for FTBFS with gcc-13

### DIFF
--- a/include/manager/metadata/metadata.h
+++ b/include/manager/metadata/metadata.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Project Tsurugi.
+ * Copyright 2020-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <memory>

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Project Tsurugi.
+ * Copyright 2020-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 #include "manager/metadata/common/utility.h"
 
 #include <charconv>
+#include <cstdint>
 #include <type_traits>
 
 #include "manager/metadata/common/message.h"

--- a/src/dao/postgresql/dao_pg.cpp
+++ b/src/dao/postgresql/dao_pg.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Project Tsurugi.
+ * Copyright 2020-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,8 +97,7 @@ void DaoPg::create_prepared_statements() {
   delete_statements_.emplace(Object::NAME, delete_by_name_statement);
 }
 
-template <typename T,
-          typename = std::enable_if_t<std::is_base_of_v<Statement, T>>>
+template <typename T, typename>
 ErrorCode DaoPg::exec_prepare(
     const std::unordered_map<std::string, T>& statements) const {
   ErrorCode error = ErrorCode::UNKNOWN;

--- a/src/helper/logging_helper.cpp
+++ b/src/helper/logging_helper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Project Tsurugi.
+ * Copyright 2020-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 #include "manager/metadata/helper/logging_helper.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <iterator>
 #include <string>
 #include <vector>


### PR DESCRIPTION
`<cstdint>` の include が足りていない箇所があり g++-13 でコンパイルエラーになる問題の修正、
(参考: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes)
および、テンプレートパラメータの二重宣言で g++-12, g++-13 および clang++の多くのバージョンでコンパイルエラーになる問題の修正です。

(tsurugidb ビルド時に使用する、`BUILD_TESTS=OFF` の範囲のみの修正になります)

