### PR TITLE
ci: supports CI on Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -29,7 +29,7 @@ jobs:
           mkdir ci_test
 
       - name: Checkout_Postgresql
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ci_test
           submodules: true
@@ -55,7 +55,7 @@ jobs:
           mkdir ci_test2
 
       - name: Checkout_Json
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ci_test2
           submodules: true

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
     name: Build Metadata-Manager ( ${{ matrix.os }} )
     runs-on: [self-hosted, docker]
     timeout-minutes: 30

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -43,5 +43,5 @@ endif()
 
 function(set_compile_options target_name)
     target_compile_options(${target_name}
-        PRIVATE -Wall -Wextra -Werror)
+        PRIVATE -Wall -Wextra -Werror -Wno-overloaded-virtual)
 endfunction(set_compile_options)

--- a/test/src/test/scenario_test.cpp
+++ b/test/src/test/scenario_test.cpp
@@ -812,7 +812,7 @@ TEST_P(UpdateTest, test_update) {
 
   auto update_data_creator = metadata_test->get_update_data_creator();
   // Generate data for updating.
-  auto ut_metadata_update = std::move(update_data_creator(before_ptree));
+  auto ut_metadata_update = update_data_creator(before_ptree);
 
   auto updated_metadata = ut_metadata_update->get_metadata_ptree();
   // Update metadata.


### PR DESCRIPTION
- add build matrix `ubuntu-24.04` for CI.
- suppress warnings in test sources with gcc-13.