### PR TITLE
Add support for time zone data types.

### DIFF
--- a/include/manager/metadata/dao/common/pg_type.h
+++ b/include/manager/metadata/dao/common/pg_type.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Project Tsurugi.
+ * Copyright 2021-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@ class PgType {
     static constexpr std::uint32_t kTimetz = 1266;
     static constexpr std::uint32_t kTimestamp = 1114;
     static constexpr std::uint32_t kTimestamptz = 1184;
-    static constexpr std::uint32_t kInterval = 1186;
   };
 
   /**
@@ -59,7 +58,6 @@ class PgType {
     static constexpr const char* const kTimetz = "timetz";
     static constexpr const char* const kTimestamp = "timestamp";
     static constexpr const char* const kTimestamptz = "timestamptz";
-    static constexpr const char* const kInterval = "interval";
   };
 };
 

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -125,7 +125,11 @@ INSERT INTO tg_catalog.types (format_version, generation, id, name, pg_data_type
 INSERT INTO tg_catalog.types (format_version, generation, id, name, pg_data_type, pg_data_type_name, pg_data_type_qualified_name) values (1, 1, 1082, 'DATE', 1082,'date','date');
 -- TIME
 INSERT INTO tg_catalog.types (format_version, generation, id, name, pg_data_type, pg_data_type_name, pg_data_type_qualified_name) values (1, 1, 1083, 'TIME', 1083,'time','time');
+-- TIMETZ
+INSERT INTO tg_catalog.types (format_version, generation, id, name, pg_data_type, pg_data_type_name, pg_data_type_qualified_name) values (1, 1, 1266, 'TIMETZ', 1266,'timetz','timetz');
 -- TIMESTAMP
 INSERT INTO tg_catalog.types (format_version, generation, id, name, pg_data_type, pg_data_type_name, pg_data_type_qualified_name) values (1, 1, 1114, 'TIMESTAMP', 1114,'timestamp','timestamp');
+-- TIMESTAMPTZ
+INSERT INTO tg_catalog.types (format_version, generation, id, name, pg_data_type, pg_data_type_name, pg_data_type_qualified_name) values (1, 1, 1184, 'TIMESTAMPTZ', 1184,'timestamptz','timestamptz');
 
 GRANT ALL ON ALL TABLES IN SCHEMA tg_catalog To current_user;

--- a/src/dao/json/datatypes_dao_json.cpp
+++ b/src/dao/json/datatypes_dao_json.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Project Tsurugi.
+ * Copyright 2021-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,18 +174,6 @@ ErrorCode DataTypesDaoJson::prepare() {
     datatype.put(DataTypes::PG_DATA_TYPE_NAME, "timestamptz");
     datatype.put(DataTypes::PG_DATA_TYPE_QUALIFIED_NAME,
                  PgType::TypeName::kTimestamptz);
-    datatypes.push_back(std::make_pair("", datatype));
-
-    // INTERVAL :
-    datatype.put(DataTypes::FORMAT_VERSION, DataTypes::format_version());
-    datatype.put(DataTypes::GENERATION, DataTypes::generation());
-    datatype.put(DataTypes::ID,
-                 static_cast<ObjectIdType>(DataTypes::DataTypesId::INTERVAL));
-    datatype.put(DataTypes::NAME, "INTERVAL");
-    datatype.put(DataTypes::PG_DATA_TYPE, PgType::TypeOid::kInterval);
-    datatype.put(DataTypes::PG_DATA_TYPE_NAME, "interval");
-    datatype.put(DataTypes::PG_DATA_TYPE_QUALIFIED_NAME,
-                 PgType::TypeName::kInterval);
     datatypes.push_back(std::make_pair("", datatype));
   }
 

--- a/test/extended/json/expected/oid
+++ b/test/extended/json/expected/oid
@@ -1,2 +1,1 @@
-tables=10
-column=31
+global=100042

--- a/test/extended/json/expected/result.txt
+++ b/test/extended/json/expected/result.txt
@@ -3,13 +3,13 @@
 === Start test of add and get of Tables class. ===
 --- get table metadata by table name. ---
 --- table metadata ---
-         id: [1]
-       name: [table_1]
+         id: [100002]
+       name: [table_100002]
   namespace: [public]
  numberOfTu: [123]
 --- columns metadata ---
-         id: [1]
-    tableId: [1]
+         id: [100003]
+    tableId: [100002]
        name: [column_1]
  columnNumb: [1]
  dataTypeId: [700]
@@ -18,8 +18,8 @@
   isNotNull: [0]
  defaultExp: [--]
   ------------------
-         id: [2]
-    tableId: [1]
+         id: [100004]
+    tableId: [100002]
        name: [column_2]
  columnNumb: [2]
  dataTypeId: [1043]
@@ -28,8 +28,8 @@
   isNotNull: [0]
  defaultExp: [--]
   ------------------
-         id: [3]
-    tableId: [1]
+         id: [100005]
+    tableId: [100002]
        name: [column_3]
  columnNumb: [3]
  dataTypeId: [1042]
@@ -40,13 +40,13 @@
   ------------------
 --- get table metadata by table id. ---
 --- table metadata ---
-         id: [1]
-       name: [table_1]
+         id: [100002]
+       name: [table_100002]
   namespace: [public]
  numberOfTu: [123]
 --- columns metadata ---
-         id: [1]
-    tableId: [1]
+         id: [100003]
+    tableId: [100002]
        name: [column_1]
  columnNumb: [1]
  dataTypeId: [700]
@@ -55,8 +55,8 @@
   isNotNull: [0]
  defaultExp: [--]
   ------------------
-         id: [2]
-    tableId: [1]
+         id: [100004]
+    tableId: [100002]
        name: [column_2]
  columnNumb: [2]
  dataTypeId: [1043]
@@ -65,8 +65,8 @@
   isNotNull: [0]
  defaultExp: [--]
   ------------------
-         id: [3]
-    tableId: [1]
+         id: [100005]
+    tableId: [100002]
        name: [column_3]
  columnNumb: [3]
  dataTypeId: [1042]
@@ -79,13 +79,13 @@
 
 === Start test of update of Tables class. ===
  --- table metadata ---
-         id: [2] --> [2]
-       name: [table_2] --> [table_2-update]
+         id: [100006] --> [100006]
+       name: [table_100006] --> [table_100006-update]
   namespace: [public] --> [public-update]
  numberOfTu: [123] --> [246]
 --- columns metadata ---
-         id: [4] --> [--]
-    tableId: [2] --> [--]
+         id: [100007] --> [--]
+    tableId: [100006] --> [--]
        name: [column_1] --> [--]
  columnNumb: [1] --> [--]
  dataTypeId: [700] --> [--]
@@ -94,8 +94,8 @@
   isNotNull: [0] --> [--]
  defaultExp: [--] --> [--]
  ------------------
-         id: [5] --> [5]
-    tableId: [2] --> [2]
+         id: [100008] --> [100008]
+    tableId: [100006] --> [100006]
        name: [column_2] --> [column_2-update]
  columnNumb: [2] --> [1]
  dataTypeId: [1043] --> [20]
@@ -104,8 +104,8 @@
   isNotNull: [0] --> [1]
  defaultExp: [--] --> [-1]
  ------------------
-         id: [6] --> [6]
-    tableId: [2] --> [2]
+         id: [100009] --> [100009]
+    tableId: [100006] --> [100006]
        name: [column_3] --> [column_3-update]
  columnNumb: [3] --> [2]
  dataTypeId: [1042] --> [1043]
@@ -114,8 +114,8 @@
   isNotNull: [1] --> [0]
  defaultExp: [--] --> [default-string]
  ------------------
-         id: [--] --> [7]
-    tableId: [--] --> [2]
+         id: [--] --> [100010]
+    tableId: [--] --> [100006]
        name: [--] --> [new-col]
  columnNumb: [--] --> [3]
  dataTypeId: [--] --> [23]
@@ -127,18 +127,17 @@
 === Done test of update of Tables class. ===
 
 === Start test of remove of Tables class. ===
-=== Done test of remove of Tables class. ===
-remove table name :table_3, id:3
-remove table name :table_5, id:5
-remove table name :table_6, id:6
-remove table name :table_4, id:4
+remove table name :table_100023, id:100023
+remove table name :table_100015, id:100015
+remove table name :table_100011, id:100011
+remove table name :table_100019, id:100019
 can't remove table name not exists :table_name_not_exists
-remove table id:7
-remove table id:9
-remove table id:10
-remove table id:8
+remove table id:100039
+remove table id:100031
+remove table id:100027
+remove table id:100035
 can't remove table id not exists :0
-=== remove table functions test done. ===
+=== Done test of remove of Tables class. ===
 
 === Start test of get of DataTypes class. ===
 DataTypes -> FORMAT_VERSION:[1] / GENERATION:[1] / ID:[23] / NAME:[INT32]
@@ -153,7 +152,6 @@ DataTypes -> FORMAT_VERSION:[1] / GENERATION:[1] / ID:[1083] / NAME:[TIME]
 DataTypes -> FORMAT_VERSION:[1] / GENERATION:[1] / ID:[1266] / NAME:[TIMETZ]
 DataTypes -> FORMAT_VERSION:[1] / GENERATION:[1] / ID:[1114] / NAME:[TIMESTAMP]
 DataTypes -> FORMAT_VERSION:[1] / GENERATION:[1] / ID:[1184] / NAME:[TIMESTAMPTZ]
-DataTypes -> FORMAT_VERSION:[1] / GENERATION:[1] / ID:[1186] / NAME:[INTERVAL]
 === Done test of get of DataTypes class. ===
 
 Tables add and get functions test: Success

--- a/test/src/matadata/ut_datattypes_metadata.cpp
+++ b/test/src/matadata/ut_datattypes_metadata.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Project Tsurugi.
+ * Copyright 2022-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,6 @@ struct DataTypesName {
   static constexpr char TIMETZ[]      = "TIMETZ";
   static constexpr char TIMESTAMP[]   = "TIMESTAMP";
   static constexpr char TIMESTAMPTZ[] = "TIMESTAMPTZ";
-  static constexpr char INTERVAL[]    = "INTERVAL";
 };
 // PostgreSQL data type oid
 struct PgDataType {
@@ -54,7 +53,6 @@ struct PgDataType {
   static constexpr char TIMETZ[]      = "1266";
   static constexpr char TIMESTAMP[]   = "1114";
   static constexpr char TIMESTAMPTZ[] = "1184";
-  static constexpr char INTERVAL[]    = "1186";
 };
 // PostgreSQL data type name
 struct PgDataTypeName {
@@ -70,7 +68,6 @@ struct PgDataTypeName {
   static constexpr char TIMETZ[]      = "timetz";
   static constexpr char TIMESTAMP[]   = "timestamp";
   static constexpr char TIMESTAMPTZ[] = "timestamptz";
-  static constexpr char INTERVAL[]    = "interval";
 };
 // PostgreSQL internal qualified data type name
 struct PgDataTypeQualifiedName {
@@ -86,7 +83,6 @@ struct PgDataTypeQualifiedName {
   static constexpr char TIMETZ[]      = "timetz";
   static constexpr char TIMESTAMP[]   = "timestamp";
   static constexpr char TIMESTAMPTZ[] = "timestamptz";
-  static constexpr char INTERVAL[]    = "interval";
 };
 
 // a list of tsurugi data type id
@@ -103,7 +99,6 @@ std::vector<std::string> DataTypesIdList = {
     std::to_string(static_cast<ObjectId>(DataTypes::DataTypesId::TIMETZ)),
     std::to_string(static_cast<ObjectId>(DataTypes::DataTypesId::TIMESTAMP)),
     std::to_string(static_cast<ObjectId>(DataTypes::DataTypesId::TIMESTAMPTZ)),
-    std::to_string(static_cast<ObjectId>(DataTypes::DataTypesId::INTERVAL)),
 };
 // a list of tsurugi data type name
 std::vector<std::string> DataTypesNameList = {
@@ -112,15 +107,13 @@ std::vector<std::string> DataTypesNameList = {
     DataTypesName::CHAR,      DataTypesName::VARCHAR,
     DataTypesName::NUMERIC,   DataTypesName::DATE,
     DataTypesName::TIME,      DataTypesName::TIMETZ,
-    DataTypesName::TIMESTAMP, DataTypesName::TIMESTAMPTZ,
-    DataTypesName::INTERVAL};
+    DataTypesName::TIMESTAMP, DataTypesName::TIMESTAMPTZ};
 // a list of PostgreSQL data type oid
 std::vector<std::string> PgDataTypeList = {
     PgDataType::INT32,   PgDataType::INT64,     PgDataType::FLOAT32,
     PgDataType::FLOAT64, PgDataType::CHAR,      PgDataType::VARCHAR,
     PgDataType::NUMERIC, PgDataType::DATE,      PgDataType::TIME,
-    PgDataType::TIMETZ,  PgDataType::TIMESTAMP, PgDataType::TIMESTAMPTZ,
-    PgDataType::INTERVAL};
+    PgDataType::TIMETZ,  PgDataType::TIMESTAMP, PgDataType::TIMESTAMPTZ};
 // a list of PostgreSQL data type name
 std::vector<std::string> PgDataTypeNameList = {
     PgDataTypeName::INT32,     PgDataTypeName::INT64,
@@ -128,8 +121,7 @@ std::vector<std::string> PgDataTypeNameList = {
     PgDataTypeName::CHAR,      PgDataTypeName::VARCHAR,
     PgDataTypeName::NUMERIC,   PgDataTypeName::DATE,
     PgDataTypeName::TIME,      PgDataTypeName::TIMETZ,
-    PgDataTypeName::TIMESTAMP, PgDataTypeName::TIMESTAMPTZ,
-    PgDataTypeName::INTERVAL};
+    PgDataTypeName::TIMESTAMP, PgDataTypeName::TIMESTAMPTZ};
 // a list of PostgreSQL qualified data type name
 std::vector<std::string> PgDataTypeQualifiedNameList = {
     PgDataTypeQualifiedName::INT32,     PgDataTypeQualifiedName::INT64,
@@ -137,8 +129,7 @@ std::vector<std::string> PgDataTypeQualifiedNameList = {
     PgDataTypeQualifiedName::CHAR,      PgDataTypeQualifiedName::VARCHAR,
     PgDataTypeQualifiedName::NUMERIC,   PgDataTypeQualifiedName::DATE,
     PgDataTypeQualifiedName::TIME,      PgDataTypeQualifiedName::TIMETZ,
-    PgDataTypeQualifiedName::TIMESTAMP, PgDataTypeQualifiedName::TIMESTAMPTZ,
-    PgDataTypeQualifiedName::INTERVAL};
+    PgDataTypeQualifiedName::TIMESTAMP, PgDataTypeQualifiedName::TIMESTAMPTZ};
 
 }  // namespace
 
@@ -290,18 +281,6 @@ UtDataTypesMetadata::UtDataTypesMetadata() {
     values.put(DataTypes::PG_DATA_TYPE_QUALIFIED_NAME,
                PgDataTypeQualifiedName::TIMESTAMPTZ);
     metadata_ptree_.add_child(DataTypesName::TIMESTAMPTZ, values);
-  }
-  // INTERVAL
-  {
-    ptree values;
-    values.put(DataTypes::ID,
-               static_cast<int64_t>(DataTypes::DataTypesId::INTERVAL));
-    values.put(DataTypes::NAME, DataTypesName::INTERVAL);
-    values.put(DataTypes::PG_DATA_TYPE, PgDataType::INTERVAL);
-    values.put(DataTypes::PG_DATA_TYPE_NAME, PgDataTypeName::INTERVAL);
-    values.put(DataTypes::PG_DATA_TYPE_QUALIFIED_NAME,
-               PgDataTypeQualifiedName::INTERVAL);
-    metadata_ptree_.add_child(DataTypesName::INTERVAL, values);
   }
 }
 


### PR DESCRIPTION
時間帯付データ型のTIMETZとTIMESTAMPTZを追加サポートする

### レグレッションテスト結果

#### JSON版

~~~sh
kfujita@sumatra:~/project-tsurugi/metadata-manager/build.json$ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DDATA_STORAGE=json ..
-- The CXX compiler identification is GNU 11.4.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Doxygen: /usr/bin/doxygen (found version "1.9.1") found components: doxygen dot
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake (found version "1.74.0") found components: system filesystem
-- The target of the build is metadata-manager.
--   Default log output level for metadata-manager is ERROR.
--   Metadata is stored in JSON-file.
--   Exclude postgresql sources.
--   Exclude postgresql test sources.
-- The C compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Found Python3: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Configuring done
-- Generating done
-- Build files have been written to: /home/kfujita/project-tsurugi/metadata-manager/build.json
kfujita@sumatra:~/project-tsurugi/metadata-manager/build.json$ ninja && (sleep 0.2; ctest)
[66/66] Linking CXX executable test/src/metadata_test
Test project /home/kfujita/project-tsurugi/metadata-manager/build.json
    Start 1: test
1/1 Test #1: test .............................   Passed    3.88 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   3.88 sec
kfujita@sumatra:~/project-tsurugi/metadata-manager/build.json$
~~~

~~~sh
kfujita@sumatra:~/project-tsurugi/metadata-manager/build.json$ ../test/extended/json/expected/test_tables.sh tables_test
-----------------------------------------------------------------------
[OID file]
Succeed: There is no difference.
-----------------------------------------------------------------------
[Tables metadata]
Succeed: There is no difference.
-----------------------------------------------------------------------
[Test result]
Succeed: There is no difference.
kfujita@sumatra:~/project-tsurugi/metadata-manager/build.json$
~~~

#### PostgreSQL版

~~~sh
kfujita@sumatra:~/project-tsurugi/metadata-manager/build.pg$ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DDATA_STORAGE=postgresql ..
-- The CXX compiler identification is GNU 11.4.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Doxygen: /usr/bin/doxygen (found version "1.9.1") found components: doxygen dot
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake (found version "1.74.0") found components: system filesystem
-- Found pg_config for PostgreSQL: /home/kfujita/pgsql/bin/pg_config
--   Header file directory: /home/kfujita/pgsql/include
--   Library file directory: /home/kfujita/pgsql/lib
-- The target of the build is metadata-manager.
--   Default log output level for metadata-manager is ERROR.
--   Metadata is stored in PostgreSQL.
--   Exclude json sources.
--   Exclude json test sources.
-- The C compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Found Python3: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Configuring done
-- Generating done
-- Build files have been written to: /home/kfujita/project-tsurugi/metadata-manager/build.pg
kfujita@sumatra:~/project-tsurugi/metadata-manager/build.pg$ ninja && (sleep 0.2; ctest)
[77/77] Linking CXX executable test/src/metadata_test
Test project /home/kfujita/project-tsurugi/metadata-manager/build.pg
    Start 1: test
1/1 Test #1: test .............................   Passed    7.92 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   7.93 sec
kfujita@sumatra:~/project-tsurugi/metadata-manager/build.pg$
~~~