### PR TITLE
build: make RPATH relative

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,7 +40,7 @@ jobs:
           rm -rf build
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+          cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
           cmake --build . --target install --clean-first -- -j8
 
       - name: Cleanup_Postgresql
@@ -66,7 +66,7 @@ jobs:
           rm -rf build
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DFORCE_INSTALL_RPATH=ON -DDATA_STORAGE=json -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+          cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DDATA_STORAGE=json -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
           cmake --build . --target install --clean-first -- -j8
           make
           make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ project(metadata-manager
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 option(BUILD_TESTS "Build test programs" ON)
-option(FORCE_INSTALL_RPATH "force add lib dir of custom prefixes to INSTALL_RPATH" OFF)
 option(BUILD_DOCUMENTS "Build documents" OFF)
 
 option(ENABLE_SANITIZER "enable sanitizer on debug build" ON)

--- a/cmake/InstallOptions.cmake
+++ b/cmake/InstallOptions.cmake
@@ -28,37 +28,6 @@ function(install_custom target_name export_name)
             DESTINATION ${CMAKE_INSTALL_BINDIR}
             COMPONENT Runtime
     )
-    # Add INSTALL_RPATH from CMAKE_INSTALL_PREFIX and CMAKE_PREFIX_PATH
-    # The default behavior of CMake omits RUNPATH if it is already in CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES.
-    if (FORCE_INSTALL_RPATH)
-        get_target_property(target_type ${target_name} TYPE)
-        if (target_type STREQUAL "SHARED_LIBRARY"
-                OR target_type STREQUAL "EXECUTABLE")
-            get_target_property(rpath ${target_name} INSTALL_RPATH)
-
-            # add ${CMAKE_INSTALL_PREFIX}/lib if it is not in system link directories
-            get_filename_component(p "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-            list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${p}" is_system)
-            if (is_system STREQUAL "-1")
-                list(APPEND rpath "${p}")
-            endif()
-
-            # add each ${CMAKE_PREFIX_PATH}/lib
-            foreach (p IN LISTS CMAKE_PREFIX_PATH)
-                get_filename_component(p "${p}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-                list(APPEND rpath "${p}")
-            endforeach()
-
-            if (rpath)
-                set_target_properties(${target_name} PROPERTIES
-                    INSTALL_RPATH "${rpath}")
-            endif()
-
-            # add other than */lib paths
-            set_target_properties(${target_name} PROPERTIES
-                INSTALL_RPATH_USE_LINK_PATH ON)
-        endif()
-    endif (FORCE_INSTALL_RPATH)
     # Install include files of interface libraries manually
     # INTERFACE_INCLUDE_DIRECTORIES must contains the following entries:
     # - one or more `$<BUILD_INTERFACE:...>` paths (may be absolute paths on source-tree)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,8 +34,9 @@ target_include_directories(api
 
 set_target_properties(api
   PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}"
-  LIBRARY_OUTPUT_NAME "metadata-manager"
+    INSTALL_RPATH "\$ORIGIN/../lib"
+    LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}"
+    LIBRARY_OUTPUT_NAME "metadata-manager"
 )
 
 if (DATA_STORAGE_PG)


### PR DESCRIPTION
`FORCE_INSTALL_RPATH`を無効化し、`INSTALL_RPATH`に固定値 (`$ORIGIN/../lib`) を設定するように修正しました。  
また、CIスクリプトで指定されていた `-DFORCE_INSTALL_RPATH=ON` についても削除しました。

## レグレッションテスト結果

### JSON版

- **ビルド確認**

  ```shell-session
  postgres@ubuntu22040:build.json$ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DDATA_STORAGE=json -DCMAKE_INSTALL_PREFIX=~/.local ..
  -- The CXX compiler identification is GNU 11.4.0
  -- Detecting CXX compiler ABI info
  -- Detecting CXX compiler ABI info - done
  -- Check for working CXX compiler: /usr/bin/c++ - skipped
  -- Detecting CXX compile features
  -- Detecting CXX compile features - done
  -- Found Doxygen: /usr/bin/doxygen (found version "1.9.1") found components: doxygen missing components: dot
  -- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake (found version "1.74.0") found components: system filesystem
  -- The target of the build is metadata-manager.
  --   Default log output level for metadata-manager is ERROR.
  --   Metadata is stored in JSON-file.
  --   Exclude postgresql sources.
  --   Exclude postgresql test sources.
  -- The C compiler identification is GNU 11.4.0
  -- Detecting C compiler ABI info
  -- Detecting C compiler ABI info - done
  -- Check for working C compiler: /usr/bin/cc - skipped
  -- Detecting C compile features
  -- Detecting C compile features - done
  -- Looking for pthread.h
  -- Looking for pthread.h - found
  -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
  -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
  -- Found Threads: TRUE
  -- Configuring done
  -- Generating done
  -- Build files have been written to: /home/postgres/work/metadata-manager/build.json
  ```

  ```shell-session
  postgres@ubuntu22040:build.json$ ninja
  [66/66] Linking CXX executable test/src/metadata_test
  ```

- **機能確認**

  ```shell-session
  postgres@ubuntu22040:build.json$ ctest
  Test project /home/postgres/work/metadata-manager/build.json
      Start 1: test
  1/1 Test #1: test .............................   Passed    1.06 sec

  100% tests passed, 0 tests failed out of 1

  Total Test time (real) =   1.06 sec
  ```

- **`RPATH`設定状況の確認**

  ```shell-session
  postgres@ubuntu22040:build.json$ ninja install
  [0/1] Install the project...
  -- Install configuration: "Debug"
  -- Installing: /home/postgres/.local/lib/cmake/metadata-manager/metadata-manager-config.cmake
  -- Installing: /home/postgres/.local/lib/cmake/metadata-manager/metadata-manager-config-version.cmake
  -- Installing: /home/postgres/.local/lib/cmake/metadata-manager/metadata-manager-targets.cmake
  -- Installing: /home/postgres/.local/lib/cmake/metadata-manager/metadata-manager-targets-debug.cmake
  -- Installing: /home/postgres/.local/include/manager
  -- Installing: /home/postgres/.local/include/manager/manager
  -- Installing: /home/postgres/.local/include/manager/manager/metadata
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/statistics.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/roles.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/provider
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/provider/metadata_provider.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/datatypes.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/common
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/common/config.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/common/utility.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/common/jwt_claims.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/common/message.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/metadata_factory.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/metadata.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/constraints.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/log
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/log/log_controller.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/log/default_logger.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/log/logging.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/indexes.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/tables.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/tables_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/privileges_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/statistics_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/index_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/db_session_manager_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/datatypes_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/constraints_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/roles_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/columns_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/object_id_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/common
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/common/pg_type.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/common/statements.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/index_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/dbc_utils_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/roles_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/statistics_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/constraints_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/tables_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/datatypes_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/pg_common.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/privileges_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/columns_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/db_session_manager_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/dao.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/db_session_manager.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/helper
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/helper/logging_helper.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/helper/table_metadata_helper.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/helper/ptree_helper.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/index.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/error_code.h
  -- Installing: /home/postgres/.local/lib/libmetadata-manager.so
  -- Set runtime path of "/home/postgres/.local/lib/libmetadata-manager.so" to "$ORIGIN/../lib"
  -- Up-to-date: /home/postgres/.local/include
  -- Installing: /home/postgres/.local/include/gmock
  -- Installing: /home/postgres/.local/include/gmock/gmock-matchers.h
  -- Installing: /home/postgres/.local/include/gmock/internal
  -- Installing: /home/postgres/.local/include/gmock/internal/gmock-pp.h
  -- Installing: /home/postgres/.local/include/gmock/internal/gmock-internal-utils.h
  -- Installing: /home/postgres/.local/include/gmock/internal/gmock-port.h
  -- Installing: /home/postgres/.local/include/gmock/internal/custom
  -- Installing: /home/postgres/.local/include/gmock/internal/custom/gmock-matchers.h
  -- Installing: /home/postgres/.local/include/gmock/internal/custom/README.md
  -- Installing: /home/postgres/.local/include/gmock/internal/custom/gmock-generated-actions.h
  -- Installing: /home/postgres/.local/include/gmock/internal/custom/gmock-port.h
  -- Installing: /home/postgres/.local/include/gmock/gmock-more-actions.h
  -- Installing: /home/postgres/.local/include/gmock/gmock-spec-builders.h
  -- Installing: /home/postgres/.local/include/gmock/gmock-actions.h
  -- Installing: /home/postgres/.local/include/gmock/gmock-cardinalities.h
  -- Installing: /home/postgres/.local/include/gmock/gmock.h
  -- Installing: /home/postgres/.local/include/gmock/gmock-more-matchers.h
  -- Installing: /home/postgres/.local/include/gmock/gmock-nice-strict.h
  -- Installing: /home/postgres/.local/include/gmock/gmock-function-mocker.h
  -- Installing: /home/postgres/.local/lib/libgmock.a
  -- Installing: /home/postgres/.local/lib/libgmock_main.a
  -- Installing: /home/postgres/.local/lib/pkgconfig/gmock.pc
  -- Installing: /home/postgres/.local/lib/pkgconfig/gmock_main.pc
  -- Installing: /home/postgres/.local/lib/cmake/GTest/GTestTargets.cmake
  -- Installing: /home/postgres/.local/lib/cmake/GTest/GTestTargets-debug.cmake
  -- Installing: /home/postgres/.local/lib/cmake/GTest/GTestConfigVersion.cmake
  -- Installing: /home/postgres/.local/lib/cmake/GTest/GTestConfig.cmake
  -- Up-to-date: /home/postgres/.local/include
  -- Installing: /home/postgres/.local/include/gtest
  -- Installing: /home/postgres/.local/include/gtest/gtest-printers.h
  -- Installing: /home/postgres/.local/include/gtest/internal
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-type-util.h
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-param-util.h
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-string.h
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-filepath.h
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-internal.h
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-port-arch.h
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-port.h
  -- Installing: /home/postgres/.local/include/gtest/internal/custom
  -- Installing: /home/postgres/.local/include/gtest/internal/custom/gtest-printers.h
  -- Installing: /home/postgres/.local/include/gtest/internal/custom/README.md
  -- Installing: /home/postgres/.local/include/gtest/internal/custom/gtest.h
  -- Installing: /home/postgres/.local/include/gtest/internal/custom/gtest-port.h
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-death-test-internal.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-param-test.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-assertion-result.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-typed-test.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-matchers.h
  -- Installing: /home/postgres/.local/include/gtest/gtest_pred_impl.h
  -- Installing: /home/postgres/.local/include/gtest/gtest.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-test-part.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-message.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-spi.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-death-test.h
  -- Installing: /home/postgres/.local/include/gtest/gtest_prod.h
  -- Installing: /home/postgres/.local/lib/libgtest.a
  -- Installing: /home/postgres/.local/lib/libgtest_main.a
  -- Installing: /home/postgres/.local/lib/pkgconfig/gtest.pc
  -- Installing: /home/postgres/.local/lib/pkgconfig/gtest_main.pc
  ```

  ```shell-session
  postgres@ubuntu22040:build.json$ objdump -x ~/.local/lib/libmetadata-manager.so | grep -E '\bR.*PATH\b'
    RUNPATH              $ORIGIN/../lib
  ```

- **CMakeバリエーション確認**
  - ***`FORCE_INSTALL_RPATH=ON`***

    ```shell-session
    postgres@ubuntu22040:build.json$ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DFORCE_INSTALL_RPATH=ON -DDATA_STORAGE=json -DCMAKE_INSTALL_PREFIX=~/.local ..
    -- The CXX compiler identification is GNU 11.4.0
    -- Detecting CXX compiler ABI info
    -- Detecting CXX compiler ABI info - done
    -- Check for working CXX compiler: /usr/bin/c++ - skipped
    -- Detecting CXX compile features
    -- Detecting CXX compile features - done
    -- Found Doxygen: /usr/bin/doxygen (found version "1.9.1") found components: doxygen missing components: dot
    -- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake (found version "1.74.0") found components: system filesystem
    -- The target of the build is metadata-manager.
    --   Default log output level for metadata-manager is ERROR.
    --   Metadata is stored in JSON-file.
    --   Exclude postgresql sources.
    --   Exclude postgresql test sources.
    -- The C compiler identification is GNU 11.4.0
    -- Detecting C compiler ABI info
    -- Detecting C compiler ABI info - done
    -- Check for working C compiler: /usr/bin/cc - skipped
    -- Detecting C compile features
    -- Detecting C compile features - done
    -- Looking for pthread.h
    -- Looking for pthread.h - found
    -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
    -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
    -- Found Threads: TRUE
    -- Configuring done
    -- Generating done
    CMake Warning:
      Manually-specified variables were not used by the project:

        FORCE_INSTALL_RPATH


    -- Build files have been written to: /home/postgres/work/metadata-manager/build.json
    ```

  - ***`FORCE_INSTALL_RPATH=OFF`***

    ```shell-session
    postgres@ubuntu22040:build.json$ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DFORCE_INSTALL_RPATH=OFF -DDATA_STORAGE=json -DCMAKE_INSTALL_PREFIX=~/.local ..
    -- The CXX compiler identification is GNU 11.4.0
    -- Detecting CXX compiler ABI info
    -- Detecting CXX compiler ABI info - done
    -- Check for working CXX compiler: /usr/bin/c++ - skipped
    -- Detecting CXX compile features
    -- Detecting CXX compile features - done
    -- Found Doxygen: /usr/bin/doxygen (found version "1.9.1") found components: doxygen missing components: dot
    -- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake (found version "1.74.0") found components: system filesystem
    -- The target of the build is metadata-manager.
    --   Default log output level for metadata-manager is ERROR.
    --   Metadata is stored in JSON-file.
    --   Exclude postgresql sources.
    --   Exclude postgresql test sources.
    -- The C compiler identification is GNU 11.4.0
    -- Detecting C compiler ABI info
    -- Detecting C compiler ABI info - done
    -- Check for working C compiler: /usr/bin/cc - skipped
    -- Detecting C compile features
    -- Detecting C compile features - done
    -- Looking for pthread.h
    -- Looking for pthread.h - found
    -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
    -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
    -- Found Threads: TRUE
    -- Configuring done
    -- Generating done
    CMake Warning:
      Manually-specified variables were not used by the project:

        FORCE_INSTALL_RPATH


    -- Build files have been written to: /home/postgres/work/metadata-manager/build.json
    ```

### PostgreSQL版

- **ビルド確認**

  ```shell-session
  postgres@ubuntu22040:build.pg$ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DDATA_STORAGE=postgresql -DCMAKE_INSTALL_PREFIX=~/.local ..
  -- The CXX compiler identification is GNU 11.4.0
  -- Detecting CXX compiler ABI info
  -- Detecting CXX compiler ABI info - done
  -- Check for working CXX compiler: /usr/bin/c++ - skipped
  -- Detecting CXX compile features
  -- Detecting CXX compile features - done
  -- Found Doxygen: /usr/bin/doxygen (found version "1.9.1") found components: doxygen missing components: dot
  -- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake (found version "1.74.0") found components: system filesystem
  -- Found pg_config for PostgreSQL: /home/postgres/.local/pgsql/current/bin/pg_config
  --   Header file directory: /home/postgres/.local/pgsql/15/include
  --   Library file directory: /home/postgres/.local/pgsql/15/lib
  -- The target of the build is metadata-manager.
  --   Default log output level for metadata-manager is ERROR.
  --   Metadata is stored in PostgreSQL.
  --   Exclude json sources.
  --   Exclude json test sources.
  -- The C compiler identification is GNU 11.4.0
  -- Detecting C compiler ABI info
  -- Detecting C compiler ABI info - done
  -- Check for working C compiler: /usr/bin/cc - skipped
  -- Detecting C compile features
  -- Detecting C compile features - done
  -- Looking for pthread.h
  -- Looking for pthread.h - found
  -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
  -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
  -- Found Threads: TRUE
  -- Configuring done
  -- Generating done
  -- Build files have been written to: /home/postgres/work/metadata-manager/build.pg
  ```

  ```shell-session
  postgres@ubuntu22040:build.pg$ ninja
  [77/77] Linking CXX executable test/src/metadata_test
  ```

- **機能確認**
  - **PostgreSQL 未起動**

    ```shell-session
    postgres@ubuntu22040:build.pg$ pg_ctl status
    pg_ctl: no server running

    postgres@ubuntu22040:build.pg$ ctest
    Test project /home/postgres/work/metadata-manager/build.pg
        Start 1: test
    1/1 Test #1: test .............................   Passed    0.40 sec

    100% tests passed, 0 tests failed out of 1

    Total Test time (real) =   0.41 sec
    ```

  - **PostgreSQL 起動中**

    ```shell-session
    postgres@ubuntu22040:build.pg$ pg_ctl status
    pg_ctl: server is running (PID: 1388748)
    /home/postgres/.local/pgsql/15/bin/postgres "-D" "/home/postgres/.tsurugi_data/pg_data/15/metadata"

    postgres@ubuntu22040:build.pg$ ctest
    Test project /home/postgres/work/metadata-manager/build.pg
        Start 1: test
    1/1 Test #1: test .............................   Passed   15.85 sec

    100% tests passed, 0 tests failed out of 1

    Total Test time (real) =  15.85 sec
    ```

- **`RPATH`設定状況の確認**

  ```shell-session
  postgres@ubuntu22040:build.pg$ ninja install
  [0/1] Install the project...
  -- Install configuration: "Debug"
  -- Installing: /home/postgres/.local/lib/cmake/metadata-manager/metadata-manager-config.cmake
  -- Installing: /home/postgres/.local/lib/cmake/metadata-manager/metadata-manager-config-version.cmake
  -- Installing: /home/postgres/.local/lib/cmake/metadata-manager/metadata-manager-targets.cmake
  -- Installing: /home/postgres/.local/lib/cmake/metadata-manager/metadata-manager-targets-debug.cmake
  -- Installing: /home/postgres/.local/include/manager
  -- Installing: /home/postgres/.local/include/manager/manager
  -- Installing: /home/postgres/.local/include/manager/manager/metadata
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/statistics.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/roles.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/provider
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/provider/metadata_provider.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/datatypes.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/common
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/common/config.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/common/utility.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/common/jwt_claims.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/common/message.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/metadata_factory.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/metadata.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/constraints.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/log
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/log/log_controller.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/log/default_logger.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/log/logging.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/indexes.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/tables.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/tables_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/privileges_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/statistics_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/index_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/db_session_manager_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/datatypes_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/constraints_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/roles_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/columns_dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/dao_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/json/object_id_json.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/common
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/common/pg_type.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/common/statements.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/index_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/dbc_utils_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/roles_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/statistics_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/constraints_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/tables_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/datatypes_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/pg_common.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/privileges_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/columns_dao_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/postgresql/db_session_manager_pg.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/dao.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/dao/db_session_manager.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/helper
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/helper/logging_helper.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/helper/table_metadata_helper.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/helper/ptree_helper.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/index.h
  -- Installing: /home/postgres/.local/include/manager/manager/metadata/error_code.h
  -- Installing: /home/postgres/.local/lib/libmetadata-manager.so
  -- Set runtime path of "/home/postgres/.local/lib/libmetadata-manager.so" to "$ORIGIN/../lib"
  -- Up-to-date: /home/postgres/.local/include
  -- Installing: /home/postgres/.local/include/gmock
  -- Installing: /home/postgres/.local/include/gmock/gmock-matchers.h
  -- Installing: /home/postgres/.local/include/gmock/internal
  -- Installing: /home/postgres/.local/include/gmock/internal/gmock-pp.h
  -- Installing: /home/postgres/.local/include/gmock/internal/gmock-internal-utils.h
  -- Installing: /home/postgres/.local/include/gmock/internal/gmock-port.h
  -- Installing: /home/postgres/.local/include/gmock/internal/custom
  -- Installing: /home/postgres/.local/include/gmock/internal/custom/gmock-matchers.h
  -- Installing: /home/postgres/.local/include/gmock/internal/custom/README.md
  -- Installing: /home/postgres/.local/include/gmock/internal/custom/gmock-generated-actions.h
  -- Installing: /home/postgres/.local/include/gmock/internal/custom/gmock-port.h
  -- Installing: /home/postgres/.local/include/gmock/gmock-more-actions.h
  -- Installing: /home/postgres/.local/include/gmock/gmock-spec-builders.h
  -- Installing: /home/postgres/.local/include/gmock/gmock-actions.h
  -- Installing: /home/postgres/.local/include/gmock/gmock-cardinalities.h
  -- Installing: /home/postgres/.local/include/gmock/gmock.h
  -- Installing: /home/postgres/.local/include/gmock/gmock-more-matchers.h
  -- Installing: /home/postgres/.local/include/gmock/gmock-nice-strict.h
  -- Installing: /home/postgres/.local/include/gmock/gmock-function-mocker.h
  -- Installing: /home/postgres/.local/lib/libgmock.a
  -- Installing: /home/postgres/.local/lib/libgmock_main.a
  -- Installing: /home/postgres/.local/lib/pkgconfig/gmock.pc
  -- Installing: /home/postgres/.local/lib/pkgconfig/gmock_main.pc
  -- Installing: /home/postgres/.local/lib/cmake/GTest/GTestTargets.cmake
  -- Installing: /home/postgres/.local/lib/cmake/GTest/GTestTargets-debug.cmake
  -- Installing: /home/postgres/.local/lib/cmake/GTest/GTestConfigVersion.cmake
  -- Installing: /home/postgres/.local/lib/cmake/GTest/GTestConfig.cmake
  -- Up-to-date: /home/postgres/.local/include
  -- Installing: /home/postgres/.local/include/gtest
  -- Installing: /home/postgres/.local/include/gtest/gtest-printers.h
  -- Installing: /home/postgres/.local/include/gtest/internal
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-type-util.h
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-param-util.h
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-string.h
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-filepath.h
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-internal.h
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-port-arch.h
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-port.h
  -- Installing: /home/postgres/.local/include/gtest/internal/custom
  -- Installing: /home/postgres/.local/include/gtest/internal/custom/gtest-printers.h
  -- Installing: /home/postgres/.local/include/gtest/internal/custom/README.md
  -- Installing: /home/postgres/.local/include/gtest/internal/custom/gtest.h
  -- Installing: /home/postgres/.local/include/gtest/internal/custom/gtest-port.h
  -- Installing: /home/postgres/.local/include/gtest/internal/gtest-death-test-internal.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-param-test.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-assertion-result.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-typed-test.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-matchers.h
  -- Installing: /home/postgres/.local/include/gtest/gtest_pred_impl.h
  -- Installing: /home/postgres/.local/include/gtest/gtest.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-test-part.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-message.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-spi.h
  -- Installing: /home/postgres/.local/include/gtest/gtest-death-test.h
  -- Installing: /home/postgres/.local/include/gtest/gtest_prod.h
  -- Installing: /home/postgres/.local/lib/libgtest.a
  -- Installing: /home/postgres/.local/lib/libgtest_main.a
  -- Installing: /home/postgres/.local/lib/pkgconfig/gtest.pc
  -- Installing: /home/postgres/.local/lib/pkgconfig/gtest_main.pc
  ```

  ```shell-session
  postgres@ubuntu22040:build.pg$ objdump -x ~/.local/lib/libmetadata-manager.so | grep -E '\bR.*PATH\b'
    RUNPATH              $ORIGIN/../lib
  ```

- **CMakeバリエーション確認**
  - ***`FORCE_INSTALL_RPATH=ON`***

    ```shell-session
    postgres@ubuntu22040:build.pg$ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DFORCE_INSTALL_RPATH=ON -DDATA_STORAGE=postgresql -DCMAKE_INSTALL_PREFIX=~/.local ..
    -- The CXX compiler identification is GNU 11.4.0
    -- Detecting CXX compiler ABI info
    -- Detecting CXX compiler ABI info - done
    -- Check for working CXX compiler: /usr/bin/c++ - skipped
    -- Detecting CXX compile features
    -- Detecting CXX compile features - done
    -- Found Doxygen: /usr/bin/doxygen (found version "1.9.1") found components: doxygen missing components: dot
    -- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake (found version "1.74.0") found components: system filesystem
    -- Found pg_config for PostgreSQL: /home/postgres/.local/pgsql/current/bin/pg_config
    --   Header file directory: /home/postgres/.local/pgsql/15/include
    --   Library file directory: /home/postgres/.local/pgsql/15/lib
    -- The target of the build is metadata-manager.
    --   Default log output level for metadata-manager is ERROR.
    --   Metadata is stored in PostgreSQL.
    --   Exclude json sources.
    --   Exclude json test sources.
    -- The C compiler identification is GNU 11.4.0
    -- Detecting C compiler ABI info
    -- Detecting C compiler ABI info - done
    -- Check for working C compiler: /usr/bin/cc - skipped
    -- Detecting C compile features
    -- Detecting C compile features - done
    -- Looking for pthread.h
    -- Looking for pthread.h - found
    -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
    -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
    -- Found Threads: TRUE
    -- Configuring done
    -- Generating done
    CMake Warning:
      Manually-specified variables were not used by the project:

        FORCE_INSTALL_RPATH


    -- Build files have been written to: /home/postgres/work/metadata-manager/build.pg
    ```

  - ***`FORCE_INSTALL_RPATH=OFF`***

    ```shell-session
    postgres@ubuntu22040:build.pg$ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DFORCE_INSTALL_RPATH=OFF -DDATA_STORAGE=postgresql -DCMAKE_INSTALL_PREFIX=~/.local ..
    -- The CXX compiler identification is GNU 11.4.0
    -- Detecting CXX compiler ABI info
    -- Detecting CXX compiler ABI info - done
    -- Check for working CXX compiler: /usr/bin/c++ - skipped
    -- Detecting CXX compile features
    -- Detecting CXX compile features - done
    -- Found Doxygen: /usr/bin/doxygen (found version "1.9.1") found components: doxygen missing components: dot
    -- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake (found version "1.74.0") found components: system filesystem
    -- Found pg_config for PostgreSQL: /home/postgres/.local/pgsql/current/bin/pg_config
    --   Header file directory: /home/postgres/.local/pgsql/15/include
    --   Library file directory: /home/postgres/.local/pgsql/15/lib
    -- The target of the build is metadata-manager.
    --   Default log output level for metadata-manager is ERROR.
    --   Metadata is stored in PostgreSQL.
    --   Exclude json sources.
    --   Exclude json test sources.
    -- The C compiler identification is GNU 11.4.0
    -- Detecting C compiler ABI info
    -- Detecting C compiler ABI info - done
    -- Check for working C compiler: /usr/bin/cc - skipped
    -- Detecting C compile features
    -- Detecting C compile features - done
    -- Looking for pthread.h
    -- Looking for pthread.h - found
    -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
    -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
    -- Found Threads: TRUE
    -- Configuring done
    -- Generating done
    CMake Warning:
      Manually-specified variables were not used by the project:

        FORCE_INSTALL_RPATH


    -- Build files have been written to: /home/postgres/work/metadata-manager/build.pg
    ```