### PR TITLE
build: fix RPATH settings to work even if libdir is not "lib"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 Project Tsurugi.
+# Copyright 2019-2025 Project Tsurugi.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ target_include_directories(api
 
 set_target_properties(api
   PROPERTIES
-    INSTALL_RPATH "\$ORIGIN/../lib"
+    INSTALL_RPATH "\$ORIGIN"
     LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}"
     LIBRARY_OUTPUT_NAME "metadata-manager"
 )


### PR DESCRIPTION
Tsurugi が主にサポートしている Ubuntu では、インストールディレクトリの下に `lib` ディレクトリを作成し、そこに共有ライブラリファイルを配置しますが、
RHEL 派生 Linux ディストリビューション等では、これが `lib64` ディレクトリとなることが原因で、ファイルを見つけられず tsurugidb 起動できない問題があったため、これを修正しました。

関連案件: https://github.com/project-tsurugi/tsurugi-issues/issues/1066

metadata-manager にも同様の構成設定が存在したため、同様に修正する Pull Request を作成しました。
参考: 別コンポーネントでの修正例 project-tsurugi/sharksfin#38